### PR TITLE
5.24 No Mobile Subclass

### DIFF
--- a/App1/App1.Android/App1.Android.csproj
+++ b/App1/App1.Android/App1.Android.csproj
@@ -61,7 +61,7 @@
       <Version>100.15.1</Version>
     </PackageReference>
     <PackageReference Include="VertiGIS.Mobile">
-      <Version>5.24.0-PullRequest9239.62</Version>
+      <Version>5.24.0-PullRequest9239.80</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms">
       <Version>5.0.0.2337</Version>

--- a/App1/App1.Android/App1.Android.csproj
+++ b/App1/App1.Android/App1.Android.csproj
@@ -52,16 +52,16 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Esri.ArcGISRuntime">
-      <Version>100.15.0</Version>
+      <Version>100.15.1</Version>
     </PackageReference>
     <PackageReference Include="Esri.ArcGISRuntime.Xamarin.Android">
-      <Version>100.15.0</Version>
+      <Version>100.15.1</Version>
     </PackageReference>
     <PackageReference Include="Esri.ArcGISRuntime.Xamarin.Forms">
-      <Version>100.15.0</Version>
+      <Version>100.15.1</Version>
     </PackageReference>
     <PackageReference Include="VertiGIS.Mobile">
-      <Version>5.22.0.454</Version>
+      <Version>5.24.0-PullRequest9239.62</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms">
       <Version>5.0.0.2337</Version>

--- a/App1/App1.Android/App1.Android.csproj
+++ b/App1/App1.Android/App1.Android.csproj
@@ -61,7 +61,7 @@
       <Version>100.15.1</Version>
     </PackageReference>
     <PackageReference Include="VertiGIS.Mobile">
-      <Version>5.24.0-PullRequest9239.80</Version>
+      <Version>5.24.0-PullRequest10148.155</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms">
       <Version>5.0.0.2337</Version>

--- a/App1/App1.Android/App1.Android.csproj
+++ b/App1/App1.Android/App1.Android.csproj
@@ -61,7 +61,7 @@
       <Version>100.15.1</Version>
     </PackageReference>
     <PackageReference Include="VertiGIS.Mobile">
-      <Version>5.24.0-PullRequest10148.155</Version>
+      <Version>5.24.0.160</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms">
       <Version>5.0.0.2337</Version>

--- a/App1/App1.Android/MainActivity.cs
+++ b/App1/App1.Android/MainActivity.cs
@@ -31,9 +31,9 @@ namespace App1.Droid
             var app = new App();
 
             // Handle startup urls
-            HandleOnCreateIntent(app); // Startup urls
-            HandleFullyDrawn(app); // Android diagnostics
-            HandleAppPermissions(app); // Location, bluetooth, etc.
+            HandleOnCreateIntent(); // Startup urls
+            HandleFullyDrawn(); // Android diagnostics
+            HandleAppPermissions(); // Location, bluetooth, etc.
 
             LoadApplication(app);
         }

--- a/App1/App1.UWP/App1.UWP.csproj
+++ b/App1/App1.UWP/App1.UWP.csproj
@@ -186,7 +186,7 @@
       <Version>6.2.12</Version>
     </PackageReference>
     <PackageReference Include="VertiGIS.Mobile">
-      <Version>5.24.0-PullRequest9239.62</Version>
+      <Version>5.24.0-PullRequest9239.80</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms">
       <Version>5.0.0.2337</Version>

--- a/App1/App1.UWP/App1.UWP.csproj
+++ b/App1/App1.UWP/App1.UWP.csproj
@@ -186,7 +186,7 @@
       <Version>6.2.12</Version>
     </PackageReference>
     <PackageReference Include="VertiGIS.Mobile">
-      <Version>5.24.0-PullRequest10148.155</Version>
+      <Version>5.24.0.160</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms">
       <Version>5.0.0.2337</Version>

--- a/App1/App1.UWP/App1.UWP.csproj
+++ b/App1/App1.UWP/App1.UWP.csproj
@@ -174,19 +174,19 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Esri.ArcGISRuntime">
-      <Version>100.15.0</Version>
+      <Version>100.15.1</Version>
     </PackageReference>
     <PackageReference Include="Esri.ArcGISRuntime.UWP">
-      <Version>100.15.0</Version>
+      <Version>100.15.1</Version>
     </PackageReference>
     <PackageReference Include="Esri.ArcGISRuntime.Xamarin.Forms">
-      <Version>100.15.0</Version>
+      <Version>100.15.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.12</Version>
     </PackageReference>
     <PackageReference Include="VertiGIS.Mobile">
-      <Version>5.22.0.454</Version>
+      <Version>5.24.0-PullRequest9239.62</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms">
       <Version>5.0.0.2337</Version>

--- a/App1/App1.UWP/App1.UWP.csproj
+++ b/App1/App1.UWP/App1.UWP.csproj
@@ -186,7 +186,7 @@
       <Version>6.2.12</Version>
     </PackageReference>
     <PackageReference Include="VertiGIS.Mobile">
-      <Version>5.24.0-PullRequest9239.80</Version>
+      <Version>5.24.0-PullRequest10148.155</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms">
       <Version>5.0.0.2337</Version>

--- a/App1/App1.iOS/App1.iOS.csproj
+++ b/App1/App1.iOS/App1.iOS.csproj
@@ -171,7 +171,7 @@
       <Version>2.0.3</Version>
     </PackageReference>
     <PackageReference Include="VertiGIS.Mobile">
-      <Version>5.24.0-PullRequest9239.80</Version>
+      <Version>5.24.0-PullRequest10148.155</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms">
       <Version>5.0.0.2337</Version>

--- a/App1/App1.iOS/App1.iOS.csproj
+++ b/App1/App1.iOS/App1.iOS.csproj
@@ -159,19 +159,19 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Esri.ArcGISRuntime">
-      <Version>100.15.0</Version>
+      <Version>100.15.1</Version>
     </PackageReference>
     <PackageReference Include="Esri.ArcGISRuntime.Xamarin.Forms">
-      <Version>100.15.0</Version>
+      <Version>100.15.1</Version>
     </PackageReference>
     <PackageReference Include="Esri.ArcGISRuntime.Xamarin.iOS">
-      <Version>100.15.0</Version>
+      <Version>100.15.1</Version>
     </PackageReference>
     <PackageReference Include="NETStandard.Library">
       <Version>2.0.3</Version>
     </PackageReference>
     <PackageReference Include="VertiGIS.Mobile">
-      <Version>5.22.0.454</Version>
+      <Version>5.24.0-PullRequest9239.62</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms">
       <Version>5.0.0.2337</Version>

--- a/App1/App1.iOS/App1.iOS.csproj
+++ b/App1/App1.iOS/App1.iOS.csproj
@@ -171,7 +171,7 @@
       <Version>2.0.3</Version>
     </PackageReference>
     <PackageReference Include="VertiGIS.Mobile">
-      <Version>5.24.0-PullRequest9239.62</Version>
+      <Version>5.24.0-PullRequest9239.80</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms">
       <Version>5.0.0.2337</Version>

--- a/App1/App1.iOS/App1.iOS.csproj
+++ b/App1/App1.iOS/App1.iOS.csproj
@@ -171,7 +171,7 @@
       <Version>2.0.3</Version>
     </PackageReference>
     <PackageReference Include="VertiGIS.Mobile">
-      <Version>5.24.0-PullRequest10148.155</Version>
+      <Version>5.24.0.160</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms">
       <Version>5.0.0.2337</Version>

--- a/App1/App1.iOS/AppDelegate.cs
+++ b/App1/App1.iOS/AppDelegate.cs
@@ -31,7 +31,7 @@ namespace App1.iOS
 
             // Handle startup urls
             // See below comment in OpenUrl, then uncomment the code below
-            // SetLaunchUrl(viewerApp, options);
+            // SetLaunchUrl(options);
 
             LoadApplication(viewerApp);
             return base.FinishedLaunching(app, options);
@@ -41,7 +41,7 @@ namespace App1.iOS
         {
             // Handle startup urls
             // Add a URL type to Info.plist, then uncomment the code below
-            // return HandleOpenUrl(app, url, options, _viewerApp);
+            // return HandleOpenUrl(url);
             return false;
         }
 

--- a/App1/App1/App.cs
+++ b/App1/App1/App.cs
@@ -29,7 +29,7 @@ namespace App1
         protected override async void OnStart()
         {
             await AppManager.Instance.InitializeAsync();
-            var appPage = await AppManager.Instance.Bootstrapper.LoadAppAysnc(new Uri("resource://app.json"));
+            var appPage = await AppManager.Instance.Bootstrapper.LoadAppAsync(new Uri("resource://app.json"));
             await AppManager.Instance.Bootstrapper.DisplayAppAsync(appPage.Page);
         }
 

--- a/App1/App1/App.cs
+++ b/App1/App1/App.cs
@@ -12,9 +12,10 @@ namespace App1
         {
             AppManager.Initialize(this);
             
-            // Add the styles from this page to the application - overrides styles from VertiGIS.Mobile
+            // Uncomment the following to add the styles from this page to the application.
+            // Overrides default styles provided by VertiGIS.Mobile.
             //var res = new Styles().Resources;
-            //this.Resources.MergedDictionaries.Add(res);
+            //Resources.MergedDictionaries.Add(res);
 
             MainPage = new ContentPage()
             {

--- a/App1/App1/App1.csproj
+++ b/App1/App1/App1.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Esri.ArcGISRuntime" Version="100.15.1" />
     <PackageReference Include="Esri.ArcGISRuntime.Xamarin.Forms" Version="100.15.1" />
-    <PackageReference Include="VertiGIS.Mobile" Version="5.24.0-PullRequest9239.62" />
+    <PackageReference Include="VertiGIS.Mobile" Version="5.24.0-PullRequest9239.80" />
     <PackageReference Include="Xamarin.Forms" Version="5.0.0.2337" />
   </ItemGroup>
 

--- a/App1/App1/App1.csproj
+++ b/App1/App1/App1.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Esri.ArcGISRuntime" Version="100.15.1" />
     <PackageReference Include="Esri.ArcGISRuntime.Xamarin.Forms" Version="100.15.1" />
-    <PackageReference Include="VertiGIS.Mobile" Version="5.24.0-PullRequest10148.155" />
+    <PackageReference Include="VertiGIS.Mobile" Version="5.24.0.160" />
     <PackageReference Include="Xamarin.Forms" Version="5.0.0.2337" />
   </ItemGroup>
 

--- a/App1/App1/App1.csproj
+++ b/App1/App1/App1.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Esri.ArcGISRuntime" Version="100.15.1" />
     <PackageReference Include="Esri.ArcGISRuntime.Xamarin.Forms" Version="100.15.1" />
-    <PackageReference Include="VertiGIS.Mobile" Version="5.24.0-PullRequest9239.80" />
+    <PackageReference Include="VertiGIS.Mobile" Version="5.24.0-PullRequest10148.155" />
     <PackageReference Include="Xamarin.Forms" Version="5.0.0.2337" />
   </ItemGroup>
 

--- a/App1/App1/App1.csproj
+++ b/App1/App1/App1.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Esri.ArcGISRuntime" Version="100.15.0" />
-    <PackageReference Include="Esri.ArcGISRuntime.Xamarin.Forms" Version="100.15.0" />
-    <PackageReference Include="VertiGIS.Mobile" Version="5.22.0.454" />
+    <PackageReference Include="Esri.ArcGISRuntime" Version="100.15.1" />
+    <PackageReference Include="Esri.ArcGISRuntime.Xamarin.Forms" Version="100.15.1" />
+    <PackageReference Include="VertiGIS.Mobile" Version="5.24.0-PullRequest9239.62" />
     <PackageReference Include="Xamarin.Forms" Version="5.0.0.2337" />
   </ItemGroup>
 

--- a/App1/App1/layout-large.xml
+++ b/App1/App1/layout-large.xml
@@ -30,7 +30,7 @@
       </stack>
       <stack margin="0.5" slot="bottom-left" halign="start">
         <split valign="center">
-          <button config="measureAction" icon="measure" style="round" margin="0.3"/>
+          <button config="measureAction" icon="measure" show-title="false" style="round" margin="0.3"/>
           <scalebar margin="0.3"/>
         </split>
       </stack>

--- a/App1/App1/layout-small.xml
+++ b/App1/App1/layout-small.xml
@@ -30,7 +30,7 @@
       </stack>
       <stack margin="0.5" slot="bottom-left" halign="start">
         <split valign="center">
-          <button config="measureAction" icon="measure" style="round" margin="0.3"/>
+          <button config="measureAction" icon="measure" show-title="false" style="round" margin="0.3"/>
           <scalebar margin="0.3"/>
         </split>
       </stack>


### PR DESCRIPTION
- Remove use of Mobile.App subclass.
- Make use of AppManager.
- Update App.cs.
- Fix typo and some general cleanup.