### PR TITLE
5.28 update VertiGIS Mobile version number

### DIFF
--- a/App1/App1.Android/App1.Android.csproj
+++ b/App1/App1.Android/App1.Android.csproj
@@ -61,7 +61,7 @@
       <Version>100.15.2</Version>
     </PackageReference>
     <PackageReference Include="VertiGIS.Mobile">
-      <Version>5.27.0.280</Version>
+      <Version>5.28.0.203</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms">
       <Version>5.0.0.2337</Version>

--- a/App1/App1.UWP/App1.UWP.csproj
+++ b/App1/App1.UWP/App1.UWP.csproj
@@ -186,7 +186,7 @@
       <Version>6.2.12</Version>
     </PackageReference>
     <PackageReference Include="VertiGIS.Mobile">
-      <Version>5.27.0.280</Version>
+      <Version>5.28.0.203</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms">
       <Version>5.0.0.2337</Version>

--- a/App1/App1.iOS/App1.iOS.csproj
+++ b/App1/App1.iOS/App1.iOS.csproj
@@ -171,7 +171,7 @@
       <Version>2.0.3</Version>
     </PackageReference>
     <PackageReference Include="VertiGIS.Mobile">
-      <Version>5.27.0.280</Version>
+      <Version>5.28.0.203</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms">
       <Version>5.0.0.2337</Version>

--- a/App1/App1/App1.csproj
+++ b/App1/App1/App1.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Esri.ArcGISRuntime" Version="100.15.2" />
     <PackageReference Include="Esri.ArcGISRuntime.Xamarin.Forms" Version="100.15.2" />
-    <PackageReference Include="VertiGIS.Mobile" Version="5.27.0.280" />
+    <PackageReference Include="VertiGIS.Mobile" Version="5.28.0.203" />
     <PackageReference Include="Xamarin.Forms" Version="5.0.0.2337" />
   </ItemGroup>
 


### PR DESCRIPTION
Updated the version number for VertiGIS.Mobile from 5.27.0.280 to 5.28.0.203