### PR TITLE
Add privacy info file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,10 @@ jobs:
             - uses: actions/checkout@v2
 
             # Fixes error when using newer NuGet packages that require a minimum version of Xcode
-            - name: Use Xcode 14.0.1
+            - name: Use Latest Xcode
               uses: maxim-lobanov/setup-xamarin@v1
               with:
-                  xcode-version: 14.0.1
+                  xcode-version: latest
 
             # The following two workaround steps can be removed when the following github issue is resolved: https://github.com/actions/virtual-environments/issues/5768
             - name: Restore Workaround Remove

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
               run: msbuild
               working-directory: App1/App1.Android
     iOS:
-        runs-on: macos-14
+        runs-on: macos-13
         steps:
             - uses: actions/checkout@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
               run: msbuild
               working-directory: App1/App1.Android
     iOS:
-        runs-on: macos-12
+        runs-on: macos-14
         steps:
             - uses: actions/checkout@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,11 @@ jobs:
         steps:
             - uses: actions/checkout@v2
 
+            - name: Install Xamarin.iOS
+              run: |
+                dotnet tool install --global boots
+                boots https://download.visualstudio.microsoft.com/download/pr/de7f727f-243c-4429-8773-eebd735eb1bb/da4a65f27ace7f805914ef63661e0efd/xamarin.ios-16.4.0.18.pkg
+
             # Fixes error when using newer NuGet packages that require a minimum version of Xcode
             - name: Use Xcode 14.1.0
               uses: maxim-lobanov/setup-xamarin@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,10 @@ jobs:
             - uses: actions/checkout@v2
 
             # Fixes error when using newer NuGet packages that require a minimum version of Xcode
-            - name: Use Latest Xcode
+            - name: Use Xcode 14.1.0
               uses: maxim-lobanov/setup-xamarin@v1
               with:
-                  xcode-version: latest
+                  xcode-version: 14.1.0
 
             # The following two workaround steps can be removed when the following github issue is resolved: https://github.com/actions/virtual-environments/issues/5768
             - name: Restore Workaround Remove

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
               run: msbuild
               working-directory: App1/App1.Android
     iOS:
-        runs-on: macos-latest
+        runs-on: macos-12
         steps:
             - uses: actions/checkout@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,10 @@ jobs:
                 boots https://download.visualstudio.microsoft.com/download/pr/de7f727f-243c-4429-8773-eebd735eb1bb/da4a65f27ace7f805914ef63661e0efd/xamarin.ios-16.4.0.18.pkg
 
             # Fixes error when using newer NuGet packages that require a minimum version of Xcode
-            - name: Use Xcode 14.1.0
+            - name: Use Xcode 14.3.1
               uses: maxim-lobanov/setup-xamarin@v1
               with:
-                  xcode-version: 14.1.0
+                  xcode-version: 14.3.1
 
             # The following two workaround steps can be removed when the following github issue is resolved: https://github.com/actions/virtual-environments/issues/5768
             - name: Restore Workaround Remove

--- a/App1/App1.iOS/App1.iOS.csproj
+++ b/App1/App1.iOS/App1.iOS.csproj
@@ -116,6 +116,7 @@
       <Link>Resources\app.json</Link>
     </BundleResource>
     <None Include="Entitlements.plist" />
+    <BundleResource Include="PrivacyInfo.xcprivacy" />
     <None Include="Info.plist" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <BundleResource Include="Resources\NLog.config" />

--- a/App1/App1.iOS/PrivacyInfo.xcprivacy
+++ b/App1/App1.iOS/PrivacyInfo.xcprivacy
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>NSPrivacyAccessedAPITypes</key>
+		<array>
+			<dict>
+				<key>NSPrivacyAccessedAPIType</key>
+				<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+				<key>NSPrivacyAccessedAPITypeReasons</key>
+				<array>
+					<string>C617.1</string>
+				</array>
+			</dict>
+			<dict>
+				<key>NSPrivacyAccessedAPIType</key>
+				<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+				<key>NSPrivacyAccessedAPITypeReasons</key>
+				<array>
+					<string>35F9.1</string>
+				</array>
+			</dict>
+			<dict>
+				<key>NSPrivacyAccessedAPIType</key>
+				<string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+				<key>NSPrivacyAccessedAPITypeReasons</key>
+				<array>
+					<string>E174.1</string>
+				</array>
+			</dict>
+		</array>
+	</dict>
+</plist>


### PR DESCRIPTION
Apple has introduced a new requirement that apps published through the store must contain a file, PrivacyInfo.xcprivacy, describing the reason for the use of certain APIs. This PR adds the required file to the quickstart as a demonstration for SDK users. Note that your own apps may need to include additional entries depending on what they're doing.