### PR TITLE
Windows TitleBar & Sign-In Issues (and more)

### DIFF
--- a/App1/App.xaml.cs
+++ b/App1/App.xaml.cs
@@ -72,12 +72,6 @@ namespace App1
         {
             await AppManager.Instance.InitializeAsync();
 
-            if (GlobalConfiguration.Instance.GenericApp)
-            {
-                await AppManager.Instance.Bootstrapper.DisplayAppSelectorAsync(AppManager.ActivationOptions);
-                return;
-            }
-
             var appPage = await AppManager.Instance.Bootstrapper.LoadAppAsync(new Uri("resource://app.json"));
             await AppManager.Instance.Bootstrapper.DisplayAppAsync(appPage.Page);
         }

--- a/App1/App.xaml.cs
+++ b/App1/App.xaml.cs
@@ -71,6 +71,13 @@ namespace App1
         protected override async void OnStart()
         {
             await AppManager.Instance.InitializeAsync();
+
+            if (GlobalConfiguration.Instance.GenericApp)
+            {
+                await AppManager.Instance.Bootstrapper.DisplayAppSelectorAsync(AppManager.ActivationOptions);
+                return;
+            }
+
             var appPage = await AppManager.Instance.Bootstrapper.LoadAppAsync(new Uri("resource://app.json"));
             await AppManager.Instance.Bootstrapper.DisplayAppAsync(appPage.Page);
         }

--- a/App1/App1.csproj
+++ b/App1/App1.csproj
@@ -78,6 +78,6 @@
 	<ItemGroup>
 		<PackageReference Include="Esri.ArcGISRuntime" Version="200.5.0" />
 		<PackageReference Include="Esri.ArcGISRuntime.Maui" Version="200.5.0" />
-		<PackageReference Include="VertiGIS.Mobile" Version="5.35.0.203" /> 
+		<PackageReference Include="VertiGIS.Mobile" Version="5.35.0.264" /> 
 	</ItemGroup>
 </Project>

--- a/App1/App1.csproj
+++ b/App1/App1.csproj
@@ -3,7 +3,8 @@
 	<PropertyGroup>
 		<TargetFrameworks>net8.0-android;net8.0-ios</TargetFrameworks>
 		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
-
+		<!--Explicit reference to WindowsSdkPackageVersion to workaround MSAL not displaying on certain versions of WindowsAppSdk -->
+		<WindowsSdkPackageVersion>10.0.22621.38</WindowsSdkPackageVersion>
 		<OutputType>Exe</OutputType>
 		<RootNamespace>App1</RootNamespace>
 		<UseMaui>true</UseMaui>
@@ -23,8 +24,8 @@
 
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
-		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.0</SupportedOSPlatformVersion>
+		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.0</TargetPlatformMinVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(TargetFramework)'=='net8.0-ios'">
@@ -55,9 +56,18 @@
 		<MauiAsset Include="Platforms\Windows\Assets\**">
 			<LogicalName>%(RecursiveDir)%(Filename)%(Extension)</LogicalName>
 		</MauiAsset>
+		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.250108002" />
 		<None Remove="Assets\**" />
 	</ItemGroup>
+	
+	<ItemGroup Condition="$(TargetFramework.Contains('-android'))">
+		<MauiAsset Include="Platforms\Android\Assets\**" />
+	</ItemGroup>
 
+	<ItemGroup Condition="$(TargetFramework.Contains('-ios'))">
+		<MauiAsset Include="Platforms\iOS\Resources\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
+	</ItemGroup>
+		
 	<ItemGroup>
 		<PackageReference Include="Jint" Version="4.1.0" />
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
@@ -68,6 +78,7 @@
 	<ItemGroup>
 		<PackageReference Include="Esri.ArcGISRuntime" Version="200.5.0" />
 		<PackageReference Include="Esri.ArcGISRuntime.Maui" Version="200.5.0" />
-		<PackageReference Include="VertiGIS.Mobile" Version="5.34.0.284" />
+		<!--PLACEHOLDER: Swap with 5.35 release before PR merges -->
+		<PackageReference Include="VertiGIS.Mobile" Version="5.34.0.284" /> 
 	</ItemGroup>
 </Project>

--- a/App1/App1.csproj
+++ b/App1/App1.csproj
@@ -78,6 +78,6 @@
 	<ItemGroup>
 		<PackageReference Include="Esri.ArcGISRuntime" Version="200.5.0" />
 		<PackageReference Include="Esri.ArcGISRuntime.Maui" Version="200.5.0" />
-		<PackageReference Include="VertiGIS.Mobile" Version="5.35.0.264" /> 
+		<PackageReference Include="VertiGIS.Mobile" Version="5.35.0.277" /> 
 	</ItemGroup>
 </Project>

--- a/App1/App1.csproj
+++ b/App1/App1.csproj
@@ -78,7 +78,6 @@
 	<ItemGroup>
 		<PackageReference Include="Esri.ArcGISRuntime" Version="200.5.0" />
 		<PackageReference Include="Esri.ArcGISRuntime.Maui" Version="200.5.0" />
-		<!--PLACEHOLDER: Swap with 5.35 release before PR merges -->
-		<PackageReference Include="VertiGIS.Mobile" Version="5.34.0.284" /> 
+		<PackageReference Include="VertiGIS.Mobile" Version="5.35.0.203" /> 
 	</ItemGroup>
 </Project>

--- a/App1/Platforms/Android/Assets/App.config
+++ b/App1/Platforms/Android/Assets/App.config
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <setting key="LogLevel" value="INFO" />
+  <!-- If this setting is turned on, then all localized strings will be displayed like '!Localized String!'; this is intended only for testing. -->
+  <setting key="IndicateLocalizableStrings" value="False" />
+  <setting key="GenericApp" value="False" />
+  <!-- Debugging - Use the Trimble R2 Emulator as the GNSS device on startup -->
+  <setting key="GnssEmulatorDebugging" value="False" />
+  <setting key="HapticFeedbackEnabled" value="True" />
+</configuration>

--- a/App1/Platforms/Windows/App.xaml
+++ b/App1/Platforms/Windows/App.xaml
@@ -8,6 +8,24 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="../../VertiGIS.Mobile/Platforms/Windows/VertiGISResources.xaml" />
             </ResourceDictionary.MergedDictionaries>
+
+            <x:String x:Key="CustomTitle">Studio Mobile</x:String>
+            <DataTemplate x:Key="MauiAppTitleBarTemplate">
+                <Grid>
+                    <Border
+                        Canvas.ZIndex="1"
+                        VerticalAlignment="Stretch"
+                        Background="{ThemeResource TitleBarBackground}"
+                        Margin="0,0,0,0">
+                        <TextBlock Padding="10,0"
+                            Foreground="{ThemeResource TitleBarForeground}"
+                            VerticalAlignment="Center"
+                            HorizontalAlignment="Left"
+                            Text="{ThemeResource CustomTitle}"/>
+                    </Border>
+                </Grid>
+            </DataTemplate>
+
             <Style x:Key="DefaultButtonStyle" TargetType="Button">
                 <Setter Property="Background" Value="Blue"/>
             </Style>

--- a/App1/Platforms/Windows/App.xaml.cs
+++ b/App1/Platforms/Windows/App.xaml.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.UI.Xaml;
+﻿using VertiGIS.Mobile.Platforms.Platform;
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
@@ -20,6 +20,13 @@ namespace App1.WinUI
         }
 
         protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
-    }
 
+        protected override void OnLaunched(Microsoft.UI.Xaml.LaunchActivatedEventArgs launchArgs)
+        {
+            base.OnLaunched(launchArgs);
+            AppHandlers.HandleOnLaunched();
+
+            this.Resources["CustomTitle"] = Windows.ApplicationModel.AppInfo.Current.DisplayInfo.DisplayName; ;
+        }
+    }
 }

--- a/App1/Platforms/Windows/App.xaml.cs
+++ b/App1/Platforms/Windows/App.xaml.cs
@@ -26,7 +26,7 @@ namespace App1.WinUI
             base.OnLaunched(launchArgs);
             AppHandlers.HandleOnLaunched();
 
-            this.Resources["CustomTitle"] = Windows.ApplicationModel.AppInfo.Current.DisplayInfo.DisplayName; ;
+            this.Resources["CustomTitle"] = Windows.ApplicationModel.AppInfo.Current.DisplayInfo.DisplayName;
         }
     }
 }

--- a/App1/Platforms/Windows/Assets/App.config
+++ b/App1/Platforms/Windows/Assets/App.config
@@ -3,7 +3,7 @@
   <setting key="LogLevel" value="INFO" />
   <!-- If this setting is turned on, then all localized strings will be displayed like '!Localized String!'; this is intended only for testing. -->
   <setting key="IndicateLocalizableStrings" value="False" />
-  <setting key="GenericApp" value="True" />
+  <setting key="GenericApp" value="False" />
   <!-- Debugging - Use the Trimble R2 Emulator as the GNSS device on startup -->
   <setting key="GnssEmulatorDebugging" value="False" />
   <setting key="HapticFeedbackEnabled" value="False" />

--- a/App1/Platforms/Windows/Assets/App.config
+++ b/App1/Platforms/Windows/Assets/App.config
@@ -3,7 +3,7 @@
   <setting key="LogLevel" value="INFO" />
   <!-- If this setting is turned on, then all localized strings will be displayed like '!Localized String!'; this is intended only for testing. -->
   <setting key="IndicateLocalizableStrings" value="False" />
-  <setting key="GenericApp" value="False" />
+  <setting key="GenericApp" value="True" />
   <!-- Debugging - Use the Trimble R2 Emulator as the GNSS device on startup -->
   <setting key="GnssEmulatorDebugging" value="False" />
   <setting key="HapticFeedbackEnabled" value="False" />

--- a/App1/Platforms/Windows/Assets/App.config
+++ b/App1/Platforms/Windows/Assets/App.config
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <setting key="LogLevel" value="INFO" />
+  <!-- If this setting is turned on, then all localized strings will be displayed like '!Localized String!'; this is intended only for testing. -->
+  <setting key="IndicateLocalizableStrings" value="False" />
+  <setting key="GenericApp" value="False" />
+  <!-- Debugging - Use the Trimble R2 Emulator as the GNSS device on startup -->
+  <setting key="GnssEmulatorDebugging" value="False" />
+  <setting key="HapticFeedbackEnabled" value="False" />
+</configuration>

--- a/App1/Platforms/iOS/Resources/App.config
+++ b/App1/Platforms/iOS/Resources/App.config
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <setting key="LogLevel" value="INFO" />
+  <!-- If this setting is turned on, then all localized strings will be displayed like '!Localized String!'; this is intended only for testing. -->
+  <setting key="IndicateLocalizableStrings" value="False" />
+  <setting key="GenericApp" value="False" />
+  <!-- Debugging - Use the Trimble R2 Emulator as the GNSS device on startup -->
+  <setting key="GnssEmulatorDebugging" value="False" />
+  <setting key="HapticFeedbackEnabled" value="True" />
+</configuration>


### PR DESCRIPTION
In Go / Custom, we would override the Maui title bar with the title 'Studio Mobile'. Then through code, we would set the title to the actual title of the Windows app (ie. VSM Dev Go / VSM Dev Custom / Studio Go etc. ). Add the same override option here so that the app's title will match the one given in `ApplicationTitle` (in .csproj). 

WindowsAppSdk 1.6 broke MSAL sign-in. https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/4933. When an SDK user attempts to sign-in via WebView, the WebView won't display on Windows. Setting `WindowsSdkPackageVersion` to 22621 fixes it. It could be that earlier versions of `WindowsSdkPackageVersion` packaged the wrong `Microsoft.Web.WebView2` and `Microsoft.Identity.Client` version(s).

On Windows, the App1 process will still exists in TaskManager even after closing the window. To fix this, we have to call `AppHandlers.HandleOnLaunched()` inside App.xaml.cs. This function includes Mobile's custom solution to making sure the Maui process is shutdown completely when the window is closed. 

App.config files were missing from the quickstart repo. Added it to the appropriate places in this PR to prevent unexpected bugs regarding LogViewer setting & haptic feedback.

`SupportedOSPlatformVersion` was targeting an older version of Windows, causing warnings when we try to use certain Window libraries. Update it to version 19041.0. 
