### PR TITLE
Update to 5.37 Mobile pckgs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
             - name: Use Latest Xcode
               uses: maxim-lobanov/setup-xamarin@v1
               with:
-                  xcode-version: latest
+                  xcode-version: '16.x'
 
             - name: Install .NET MAUI Workload
               run: dotnet workload install maui

--- a/App1/App1.csproj
+++ b/App1/App1.csproj
@@ -3,8 +3,6 @@
 	<PropertyGroup>
 		<TargetFrameworks>net8.0-android;net8.0-ios</TargetFrameworks>
 		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
-		<!--Explicit reference to WindowsSdkPackageVersion to workaround MSAL not displaying on certain versions of WindowsAppSdk -->
-		<WindowsSdkPackageVersion>10.0.22621.38</WindowsSdkPackageVersion>
 		<OutputType>Exe</OutputType>
 		<RootNamespace>App1</RootNamespace>
 		<UseMaui>true</UseMaui>
@@ -56,7 +54,7 @@
 		<MauiAsset Include="Platforms\Windows\Assets\**">
 			<LogicalName>%(RecursiveDir)%(Filename)%(Extension)</LogicalName>
 		</MauiAsset>
-		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.250108002" />
+		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.7.250606001" />
 		<None Remove="Assets\**" />
 	</ItemGroup>
 	
@@ -77,6 +75,6 @@
 	<ItemGroup>
 		<PackageReference Include="Esri.ArcGISRuntime" Version="200.5.0" />
 		<PackageReference Include="Esri.ArcGISRuntime.Maui" Version="200.5.0" />
-		<PackageReference Include="VertiGIS.Mobile" Version="5.36.0.191" /> 
+		<PackageReference Include="VertiGIS.Mobile" Version="5.37.0.232" /> 
 	</ItemGroup>
 </Project>

--- a/App1/Platforms/Android/AndroidManifest.xml
+++ b/App1/Platforms/Android/AndroidManifest.xml
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true"></application>
+	<uses-sdk android:minSdkVersion="30" android:targetSdkVersion="35" />
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.INTERNET" />
 </manifest>

--- a/App1/Platforms/Android/Resources/values/styles.xml
+++ b/App1/Platforms/Android/Resources/values/styles.xml
@@ -33,6 +33,7 @@
 
 		<item name="android:datePickerDialogTheme">@style/AppCompatDialogStyle</item>
 
+		<item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
 	</style>
 
 	<style name="AppTheme.Base" parent="Theme.MaterialComponents.Light.NoActionBar">


### PR DESCRIPTION
- Update packages to 5.37.232
- Update the WindowsAppSDK version to match the one used in 5.37.232
- Remove the WindowsSdkPackageVersion workaround (keeping it causes the MSAL to fail to load)